### PR TITLE
Add support for linux (using Cmake)

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,3 +1,7 @@
+#
+# THIS CMAKE FILE IS ONLY TESTED/INTENDED FOR LINUX BUILDS
+#
+
 cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -fPIC")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 2.8)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -fPIC")
+
+add_library(emu2413 STATIC
+    emu2413/2413tone.h
+    emu2413/281btone.h
+    emu2413/emu2413.c
+    emu2413/emu2413.h
+    emu2413/emutypes.h
+    emu2413/vrc7tone.h
+)
+
+
+# you must download the VST SDK and copy the directory:
+#   pluginterfaces/vst2.x
+# into vst2.x/pluginterfaces/vst2.x
+# and all the files from:
+#   public.sdk/source/vst2.x
+# into vst2.x
+include_directories( vst2.x )
+add_definitions( -D__cdecl= )
+
+add_library(vst2413p SHARED
+    RhythmDriver.cpp
+    RhythmDriver.h
+    SynthDriver.cpp
+    SynthDriver.h
+    Vst2413p.cpp
+    Vst2413p.h
+    vst2.x/audioeffectx.cpp
+    vst2.x/audioeffectx.h
+)
+
+add_library(vst2413r SHARED
+    RhythmDriver.cpp
+    RhythmDriver.h
+    SynthDriver.cpp
+    SynthDriver.h
+    Vst2413r.cpp
+    Vst2413r.h
+)
+
+add_library(vst2413s SHARED
+    RhythmDriver.cpp
+    RhythmDriver.h
+    SynthDriver.cpp
+    SynthDriver.h
+    Vst2413s.cpp
+    Vst2413s.h
+)
+
+target_link_libraries(vst2413p emu2413)
+target_link_libraries(vst2413r emu2413)
+target_link_libraries(vst2413s emu2413)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(vst2413p SHARED
     Vst2413p.h
     vst2.x/audioeffectx.cpp
     vst2.x/audioeffectx.h
+    vst2.x/audioeffect.cpp
+    vst2.x/audioeffect.h
+    vst2.x/vstplugmain.cpp
 )
 
 add_library(vst2413r SHARED
@@ -40,6 +43,11 @@ add_library(vst2413r SHARED
     SynthDriver.h
     Vst2413r.cpp
     Vst2413r.h
+    vst2.x/audioeffectx.cpp
+    vst2.x/audioeffectx.h
+    vst2.x/audioeffect.cpp
+    vst2.x/audioeffect.h
+    vst2.x/vstplugmain.cpp
 )
 
 add_library(vst2413s SHARED
@@ -49,6 +57,11 @@ add_library(vst2413s SHARED
     SynthDriver.h
     Vst2413s.cpp
     Vst2413s.h
+    vst2.x/audioeffectx.cpp
+    vst2.x/audioeffectx.h
+    vst2.x/audioeffect.cpp
+    vst2.x/audioeffect.h
+    vst2.x/vstplugmain.cpp
 )
 
 target_link_libraries(vst2413p emu2413)

--- a/source/SynthDriver.cpp
+++ b/source/SynthDriver.cpp
@@ -1,6 +1,7 @@
 #include "SynthDriver.h"
 #include "emu2413/emu2413.h"
 #include <cmath>
+#include <stdio.h>
 
 #ifdef _WIN32
 #define snprintf _snprintf


### PR DESCRIPTION
I added support for building the plugins in Linux using cmake. There is a little documentation in the CMakeLists.txt file in source. It probably could be made to use cmake for all platforms, but since you already have ways to do it on windows/mac I just got it working for linux.

There is also a tiny change in the source (adding an include to avoid errors about snprintf).

Cool project, thanks for sharing the code!