### PR TITLE
Add zlib license matching authors license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,18 @@
-See source/emu2413/readme.txt
+zlib License
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use of
+this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject to
+the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim
+   that you wrote the original software. If you use this software in a product,
+   an acknowledgment in the product documentation would be appreciated but is
+   not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
You have a license file defined at:
https://github.com/keijiro/vst2413/blob/master/source/emu2413/readme.txt

It is essentially a zlib license:
https://github.com/google/licenseclassifier/blob/main/licenses/Zlib.txt
https://choosealicense.com/licenses/zlib/

The general convention is to add your LICENSE at the top-level so it can be detected by GitHub UI and search:
<img width="1260" alt="Screenshot 2024-07-14 at 9 08 37 PM" src="https://github.com/user-attachments/assets/c5dc388e-2d9c-4dd6-8386-cdff8e586cce">

The PR will enable that functionality!
